### PR TITLE
Split verify into step1 and step2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,4 @@ mod verify_js;
 
 pub use points::{g1_from_fixed, g1_from_variable, g2_from_fixed, g2_from_variable};
 pub use randomness::derive_randomness;
-pub use verify::{verify, VerificationError};
+pub use verify::{verify, verify_step1, verify_step2, VerificationError};

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -40,6 +40,9 @@ pub fn verify(
 
 /// First step of the verification.
 /// Should not be used directly in most cases. Use [`verify`] instead.
+///
+/// This API is not stable.
+#[doc(hidden)]
 pub fn verify_step1(round: u64, previous_signature: &[u8]) -> G2Affine {
     let msg = message(round, previous_signature);
     let msg_on_g2 = msg_to_curve(&msg);
@@ -48,6 +51,9 @@ pub fn verify_step1(round: u64, previous_signature: &[u8]) -> G2Affine {
 
 /// Second step of the verification.
 /// Should not be used directly in most cases. Use [`verify`] instead.
+///
+/// This API is not stable.
+#[doc(hidden)]
 pub fn verify_step2(
     pk: &G1Affine,
     signature: &[u8],

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -45,8 +45,7 @@ pub fn verify(
 #[doc(hidden)]
 pub fn verify_step1(round: u64, previous_signature: &[u8]) -> G2Affine {
     let msg = message(round, previous_signature);
-    let msg_on_g2 = msg_to_curve(&msg);
-    msg_on_g2
+    msg_to_curve(&msg)
 }
 
 /// Second step of the verification.


### PR DESCRIPTION
This allows reducing the code size when only step 1 or only step 2 is used.

In a demo CosmWasm contract I was able to break down the code size as follows
- contract using full verification: 688K
- contract with step1 only: 461K
- contract with step2 only: 414K

That leads to those very rough size estimations:
- Basics setup (cosmwasm-std/JSON/storage/simple logic): 200 KB
- Verify Step 1: 200 KB
- Verify Step 2: 200 KB
