### PR TITLE
Implement drand verification with G1/G2 swapped

### DIFF
--- a/benches/verify.rs
+++ b/benches/verify.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use drand_verify::{g1_from_fixed, verify};
+use drand_verify::{verify, Pubkey};
 use hex_literal::hex;
 
 /// Public key League of Entropy Mainnet (curl -sS https://drand.cloudflare.com/info)
@@ -10,7 +10,7 @@ const PK_LEO_MAINNET: [u8; 48] = hex!("868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7
 
 #[bench]
 fn bench_verify(b: &mut ::test::Bencher) {
-    let pk = g1_from_fixed(PK_LEO_MAINNET).unwrap();
+    let pk = Pubkey::from_48(PK_LEO_MAINNET).unwrap();
 
     // curl -sS https://drand.cloudflare.com/public/72785
     let previous_signature = hex::decode("a609e19a03c2fcc559e8dae14900aaefe517cb55c840f6e69bc8e4f66c8d18e8a609685d9917efbfb0c37f058c2de88f13d297c7e19e0ab24813079efe57a182554ff054c7638153f9b26a60e7111f71a0ff63d9571704905d3ca6df0b031747").unwrap();

--- a/examples/drand_verify.rs
+++ b/examples/drand_verify.rs
@@ -2,13 +2,13 @@ use hex_literal::hex;
 use std::env;
 use std::process::exit;
 
-use drand_verify::{derive_randomness, g1_from_fixed, verify};
+use drand_verify::{derive_randomness, verify, Pubkey};
 
 /// Public key League of Entropy Mainnet (curl -sS https://drand.cloudflare.com/info)
 const PK_LEO_MAINNET: [u8; 48] = hex!("868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31");
 
 fn main_impl() -> i32 {
-    let pk = g1_from_fixed(PK_LEO_MAINNET).unwrap();
+    let pk = Pubkey::from_48(PK_LEO_MAINNET).unwrap();
 
     let args: Vec<String> = env::args().collect();
     if args.len() != 4 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,5 @@ mod verify;
 #[cfg(feature = "js")]
 mod verify_js;
 
-pub use points::{
-    g1_from_fixed, g1_from_fixed_unchecked, g1_from_variable, g1_from_variable_unchecked,
-    g2_from_fixed, g2_from_fixed_unchecked, g2_from_variable, g2_from_variable_unchecked,
-};
 pub use randomness::derive_randomness;
-pub use verify::{verify, verify_step1, verify_step2, VerificationError};
+pub use verify::{verify, Pubkey, VerificationError};

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,6 +1,6 @@
 use bls12_381::{
     hash_to_curve::{ExpandMsgXmd, HashToCurve},
-    Bls12, G1Affine, G2Affine, G2Prepared, G2Projective,
+    Bls12, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective,
 };
 use pairing::{group::Group, MultiMillerLoop};
 use sha2::{Digest, Sha256};
@@ -9,7 +9,10 @@ use std::fmt;
 
 const DOMAIN: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
 
-use super::points::g2_from_variable;
+use crate::points::{
+    g1_from_fixed, g1_from_fixed_unchecked, g1_from_variable, g2_from_fixed,
+    g2_from_fixed_unchecked, g2_from_variable, InvalidPoint,
+};
 
 #[derive(Debug)]
 pub enum VerificationError {
@@ -28,35 +31,96 @@ impl fmt::Display for VerificationError {
 
 impl Error for VerificationError {}
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Pubkey {
+    G1(G1Affine),
+    G2(G2Affine),
+}
+
+impl Pubkey {
+    // Creates a public key from a 48 byte representation (point on G1)
+    pub fn from_48(data: [u8; 48]) -> Result<Self, InvalidPoint> {
+        Ok(Pubkey::G1(g1_from_fixed(data)?))
+    }
+
+    /// Like [`Pubkey::from_48`] without guaranteeing that the encoding represents a valid element.
+    /// Only use this when you know for sure the encoding is correct.
+    pub fn from_48_unchecked(data: [u8; 48]) -> Result<Self, InvalidPoint> {
+        Ok(Pubkey::G1(g1_from_fixed_unchecked(data)?))
+    }
+
+    // Creates a public key from a 96 byte representation (point on G2)
+    pub fn from_96(data: [u8; 96]) -> Result<Self, InvalidPoint> {
+        Ok(Pubkey::G2(g2_from_fixed(data)?))
+    }
+
+    /// Creates a public key from a 96 byte representation (point on G2).
+    /// Like [`Pubkey::from_96`] without guaranteeing that the encoding represents a valid element.
+    /// Only use this when you know for sure the encoding is correct.
+    pub fn from_96_unchecked(data: [u8; 96]) -> Result<Self, InvalidPoint> {
+        Ok(Pubkey::G2(g2_from_fixed_unchecked(data)?))
+    }
+
+    /// Creates a public key from a 48 or 96 byte representation (point on G1 or G2).
+    pub fn from_variable(data: &[u8]) -> Result<Self, InvalidPoint> {
+        match data.len() {
+            48 => {
+                let mut buf = [0u8; 48];
+                buf[..].clone_from_slice(data);
+                Pubkey::from_48(buf)
+            }
+            96 => {
+                let mut buf = [0u8; 96];
+                buf[..].clone_from_slice(data);
+                Pubkey::from_96(buf)
+            }
+            other => Err(InvalidPoint::InvalidLength { actual: other }),
+        }
+    }
+}
+
 /// Checks beacon components to see if they are valid.
 ///
 /// For unchained mode set `previous_signature` to an empty value.
 pub fn verify(
-    pk: &G1Affine,
+    pk: &Pubkey,
     round: u64,
     previous_signature: &[u8],
     signature: &[u8],
 ) -> Result<bool, VerificationError> {
-    let msg_on_g2 = verify_step1(round, previous_signature);
-    verify_step2(pk, signature, &msg_on_g2)
+    match pk {
+        Pubkey::G1(pk) => {
+            let msg = message(round, previous_signature);
+            let msg_on_g2 = msg_to_curve_g2(&msg);
+            verify_step2_g2(pk, signature, &msg_on_g2)
+        }
+        Pubkey::G2(pk) => {
+            let msg = message(round, previous_signature);
+            let msg_on_g1 = msg_to_curve_g1(&msg);
+            verify_step2_g1(pk, signature, &msg_on_g1)
+        }
+    }
 }
 
-/// First step of the verification.
-/// Should not be used directly in most cases. Use [`verify`] instead.
-///
-/// This API is not stable.
-#[doc(hidden)]
-pub fn verify_step1(round: u64, previous_signature: &[u8]) -> G2Affine {
-    let msg = message(round, previous_signature);
-    msg_to_curve(&msg)
+fn verify_step2_g1(
+    pk: &G2Affine,
+    signature: &[u8],
+    msg_on_g1: &G1Affine,
+) -> Result<bool, VerificationError> {
+    let g2 = G2Affine::generator();
+    let sigma = match g1_from_variable(signature) {
+        Ok(sigma) => sigma,
+        Err(err) => {
+            return Err(VerificationError::InvalidPoint {
+                field: "signature".into(),
+                msg: err.to_string(),
+            })
+        }
+    };
+    Ok(fast_pairing_equality(&sigma, &g2, msg_on_g1, pk))
 }
 
-/// Second step of the verification.
-/// Should not be used directly in most cases. Use [`verify`] instead.
-///
-/// This API is not stable.
-#[doc(hidden)]
-pub fn verify_step2(
+fn verify_step2_g2(
     pk: &G1Affine,
     signature: &[u8],
     msg_on_g2: &G2Affine,
@@ -107,7 +171,12 @@ fn round_to_bytes(round: u64) -> [u8; 8] {
     round.to_be_bytes()
 }
 
-fn msg_to_curve(msg: &[u8]) -> G2Affine {
+fn msg_to_curve_g1(msg: &[u8]) -> G1Affine {
+    let g: G1Projective = HashToCurve::<ExpandMsgXmd<sha2::Sha256>>::hash_to_curve(msg, DOMAIN);
+    g.into()
+}
+
+fn msg_to_curve_g2(msg: &[u8]) -> G2Affine {
     let g: G2Projective = HashToCurve::<ExpandMsgXmd<sha2::Sha256>>::hash_to_curve(msg, DOMAIN);
     g.into()
 }
@@ -115,7 +184,6 @@ fn msg_to_curve(msg: &[u8]) -> G2Affine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::points::g1_from_fixed;
     use hex_literal::hex;
 
     /// Public key League of Entropy Mainnet (curl -sS https://drand.cloudflare.com/info)
@@ -126,7 +194,7 @@ mod tests {
 
     #[test]
     fn verify_works() {
-        let pk = g1_from_fixed(PK_LEO_MAINNET).unwrap();
+        let pk = Pubkey::from_48(PK_LEO_MAINNET).unwrap();
 
         // curl -sS https://drand.cloudflare.com/public/72785
         let previous_signature = hex::decode("a609e19a03c2fcc559e8dae14900aaefe517cb55c840f6e69bc8e4f66c8d18e8a609685d9917efbfb0c37f058c2de88f13d297c7e19e0ab24813079efe57a182554ff054c7638153f9b26a60e7111f71a0ff63d9571704905d3ca6df0b031747").unwrap();
@@ -155,7 +223,7 @@ mod tests {
 
     #[test]
     fn verify_works_for_unchained() {
-        let pk = g1_from_fixed(PK_UNCHAINED_TESTNET).unwrap();
+        let pk = Pubkey::from_48(PK_UNCHAINED_TESTNET).unwrap();
 
         // curl -sS https://pl-us.testnet.drand.sh/7672797f548f3f4748ac4bf3352fc6c6b6468c9ad40ad456a397545c6e2df5bf/public/223344
         let signature = hex::decode("94f6b85df7cce7237e8e7df66d794ddad092de5d8bb6a791b97e905aa89852e506ac36a792eba7021e22eebf34891f8914bf9a8dd9233ea0a4c5ca00ef8404999f899073dd2eade61fe54077fee8168f83dcb61a758b6883b38904054e64a433").unwrap();
@@ -174,5 +242,25 @@ mod tests {
         let wrong_signature = hex::decode("86ecea71376e78abd19aaf0ad52f462a6483626563b1023bd04815a7b953da888c74f5bf6ee672a5688603ab310026230522898f33f23a7de363c66f90ffd49ec77ebf7f6c1478a9ecd6e714b4d532ab43d044da0a16fed13b4791d7fc999e2b").unwrap();
         let result = verify(&pk, round, b"", &wrong_signature).unwrap();
         assert!(!result);
+    }
+
+    #[test]
+    fn verify_works_for_g1g2_swapped() {
+        // Test vectors provided by Yolan Romailler
+
+        /// Public key for G1/G2 swap
+        const PK_SWAPPED: [u8; 96] = hex!("876f6fa8073736e22f6ff4badaab35c637503718f7a452d178ce69c45d2d8129a54ad2f988ab10c9666f87ab603c59bf013409a5b500555da31720f8eec294d9809b8796f40d5372c71a44ca61226f1eb978310392f98074a608747f77e66c5a");
+
+        let pk = Pubkey::from_96(PK_SWAPPED).unwrap();
+
+        let signature = hex::decode("ac7c3ca14bc88bd014260f22dc016b4fe586f9313c3a549c83d195811a99a5d2d4999d4df6daec73ff51fafadd6d5bb5").unwrap();
+        let round: u64 = 3;
+        let result = verify(&pk, round, b"", &signature).unwrap();
+        assert!(result);
+
+        let signature = hex::decode("b4448d565ccad16beb6502f0cf84b4b8d4a67845ba894308a188731b8eb8fc5eb1b5bdcdcd370271436e1475c4786a4e").unwrap();
+        let round: u64 = 4;
+        let result = verify(&pk, round, b"", &signature).unwrap();
+        assert!(result);
     }
 }

--- a/src/verify_js.rs
+++ b/src/verify_js.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
-use super::points::{g1_from_variable, InvalidPoint};
-use super::verify::{verify, VerificationError};
+use super::points::InvalidPoint;
+use super::verify::{verify, Pubkey, VerificationError};
 
 struct VerifyWebError(pub String);
 
@@ -61,7 +61,7 @@ fn verify_beacon_impl(
     previous_signature_hex: &str,
     signature_hex: &str,
 ) -> Result<bool, VerifyWebError> {
-    let pk = g1_from_variable(&hex::decode(pk_hex)?)?;
+    let pk = Pubkey::from_variable(&hex::decode(pk_hex)?)?;
     let previous_signature = hex::decode(previous_signature_hex)?;
     let signature = hex::decode(signature_hex)?;
     let result = verify(&pk, round.into(), &previous_signature, &signature)?;


### PR DESCRIPTION
- Removes the need to touch g1/G2 instances in the API. A user should create a `Pubkey` instead.
- Allows using 96 byte pubkeys and 48 byte signatures